### PR TITLE
Require commit signing setting in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "git.enableCommitSigning": true,
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer"
     },


### PR DESCRIPTION
Adds the `"git.enableCommitSigning": true` setting to `.vscode/settings.json` to help ensure all pushed commits are signed.