### PR TITLE
Modify `PhysicalMemoryManager` to use a singleton-like design

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "git.enableCommitSigning": true,
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer"
     },

--- a/src/kernel/src/init.rs
+++ b/src/kernel/src/init.rs
@@ -8,6 +8,8 @@ use limine::{
     },
 };
 
+use crate::mem::pmm::PhysicalMemoryManager;
+
 #[allow(clippy::too_many_lines)]
 pub extern "C" fn init() -> ! {
     // This function is absolutely massive, and that's intentional. All of the code
@@ -51,13 +53,7 @@ pub extern "C" fn init() -> ! {
     crate::params::parse(&KERNEL_CMDLINE_REQUEST);
     crate::panic::symbols::parse(&KERNEL_FILE_REQUEST);
     crate::mem::hhdm::set(&HHDM_REQUEST);
-
-    let memory_map = MEMORY_MAP_REQUEST
-        .get_response()
-        .expect("no response to memory map request")
-        .entries();
-
-    crate::mem::pmm::init(memory_map);
+    crate::mem::pmm::PhysicalMemoryManager::init(&MEMORY_MAP_REQUEST);
 
     crate::arch::x86_64::instructions::breakpoint();
 
@@ -85,158 +81,157 @@ pub extern "C" fn init() -> ! {
     };
 
     /* SETUP KERNEL MEMORY */
-    {
-        use crate::mem::{
-            hhdm,
-            paging::{TableDepth, TableEntryFlags},
-        };
-        use libsys::page_size;
-        use limine::memory_map::EntryType;
+    // {
+    //     use crate::mem::{
+    //         hhdm,
+    //         paging::{TableDepth, TableEntryFlags},
+    //     };
+    //     use libsys::page_size;
+    //     use limine::memory_map::EntryType;
 
-        fn map_hhdm_range(
-            mapper: &mut crate::mem::mapper::Mapper,
-            mut range: core::ops::Range<usize>,
-            flags: TableEntryFlags,
-            lock_frames: bool,
-        ) {
-            let huge_page_depth = TableDepth::new(1).unwrap();
+    //     fn map_hhdm_range(
+    //         mapper: &mut crate::mem::mapper::Mapper,
+    //         mut range: core::ops::Range<usize>,
+    //         flags: TableEntryFlags,
+    //         lock_frames: bool,
+    //     ) {
+    //         let huge_page_depth = TableDepth::new(1).unwrap();
 
-            trace!("HHDM Map  {range:#X?}  {flags:?}   lock {lock_frames}");
+    //         trace!("HHDM Map  {range:#X?}  {flags:?}   lock {lock_frames}");
 
-            while !range.is_empty() {
-                if range.len() > huge_page_depth.align()
-                    && range.start.trailing_zeros() >= huge_page_depth.align().trailing_zeros()
-                {
-                    // Map a huge page
+    //         while !range.is_empty() {
+    //             if range.len() > huge_page_depth.align()
+    //                 && range.start.trailing_zeros() >= huge_page_depth.align().trailing_zeros()
+    //             {
+    //                 // Map a huge page
 
-                    let frame = Address::new(range.start).unwrap();
-                    let page = hhdm::get().offset(frame).unwrap();
-                    range.advance_by(huge_page_depth.align()).unwrap();
+    //                 let frame = Address::new(range.start).unwrap();
+    //                 let page = hhdm::get().offset(frame).unwrap();
+    //                 range.advance_by(huge_page_depth.align()).unwrap();
 
-                    mapper
-                        .map(
-                            page,
-                            huge_page_depth,
-                            frame,
-                            lock_frames,
-                            flags | TableEntryFlags::HUGE,
-                        )
-                        .expect("failed to map range")
-                } else {
-                    // Map a standard page
+    //                 mapper
+    //                     .map(
+    //                         page,
+    //                         huge_page_depth,
+    //                         frame,
+    //                         lock_frames,
+    //                         flags | TableEntryFlags::HUGE,
+    //                     )
+    //                     .expect("failed to map range")
+    //             } else {
+    //                 // Map a standard page
 
-                    let frame = Address::new(range.start).unwrap();
-                    let page = hhdm::get().offset(frame).unwrap();
-                    range.advance_by(page_size()).unwrap();
+    //                 let frame = Address::new(range.start).unwrap();
+    //                 let page = hhdm::get().offset(frame).unwrap();
+    //                 range.advance_by(page_size()).unwrap();
 
-                    mapper
-                        .map(page, TableDepth::min(), frame, lock_frames, flags)
-                        .expect("failed to map range");
-                }
-            }
-        }
+    //                 mapper
+    //                     .map(page, TableDepth::min(), frame, lock_frames, flags)
+    //                     .expect("failed to map range");
+    //             }
+    //         }
+    //     }
 
-        debug!("Preparing kernel memory system.");
+    //     debug!("Preparing kernel memory system.");
 
-        /* load and map segments */
+    //     /* load and map segments */
+    //     debug!("Mapping the higher-half direct map.");
+    //     crate::mem::with_kmapper(|kmapper| {
+    //         let mmap_entries = &mut memory_map.iter().map(|entry| {
+    //             let entry_start = usize::try_from(entry.base).unwrap();
+    //             let entry_end = usize::try_from(entry.base + entry.length).unwrap();
 
-        debug!("Mapping the higher-half direct map.");
-        crate::mem::with_kmapper(|kmapper| {
-            let mmap_entries = &mut memory_map.iter().map(|entry| {
-                let entry_start = usize::try_from(entry.base).unwrap();
-                let entry_end = usize::try_from(entry.base + entry.length).unwrap();
+    //             (entry_start..entry_end, entry.entry_type)
+    //         });
 
-                (entry_start..entry_end, entry.entry_type)
-            });
+    //         let mut last_end = 0;
+    //         while let Some((mut entry_range, entry_ty)) = mmap_entries.next() {
+    //             // collapse sequential matching entries
+    //             if let Some((end_range, _)) = mmap_entries
+    //                 .take_while(|(range, ty)| entry_range.end == range.start && entry_ty.eq(ty))
+    //                 .last()
+    //             {
+    //                 entry_range.end = end_range.end;
+    //             }
 
-            let mut last_end = 0;
-            while let Some((mut entry_range, entry_ty)) = mmap_entries.next() {
-                // collapse sequential matching entries
-                if let Some((end_range, _)) = mmap_entries
-                    .take_while(|(range, ty)| entry_range.end == range.start && entry_ty.eq(ty))
-                    .last()
-                {
-                    entry_range.end = end_range.end;
-                }
+    //             if entry_range.start > last_end {
+    //                 map_hhdm_range(
+    //                     kmapper,
+    //                     last_end..entry_range.start,
+    //                     TableEntryFlags::RW,
+    //                     true,
+    //                 );
+    //             }
 
-                if entry_range.start > last_end {
-                    map_hhdm_range(
-                        kmapper,
-                        last_end..entry_range.start,
-                        TableEntryFlags::RW,
-                        true,
-                    );
-                }
+    //             last_end = entry_range.end;
 
-                last_end = entry_range.end;
+    //             let mmap_args = match entry_ty {
+    //                 EntryType::USABLE => Some((TableEntryFlags::RW, false)),
 
-                let mmap_args = match entry_ty {
-                    EntryType::USABLE => Some((TableEntryFlags::RW, false)),
+    //                 EntryType::ACPI_NVS
+    //                 | EntryType::ACPI_RECLAIMABLE
+    //                 | EntryType::BOOTLOADER_RECLAIMABLE
+    //                 | EntryType::FRAMEBUFFER => Some((TableEntryFlags::RW, true)),
 
-                    EntryType::ACPI_NVS
-                    | EntryType::ACPI_RECLAIMABLE
-                    | EntryType::BOOTLOADER_RECLAIMABLE
-                    | EntryType::FRAMEBUFFER => Some((TableEntryFlags::RW, true)),
+    //                 EntryType::RESERVED | EntryType::EXECUTABLE_AND_MODULES => {
+    //                     Some((TableEntryFlags::RO, true))
+    //                 }
 
-                    EntryType::RESERVED | EntryType::EXECUTABLE_AND_MODULES => {
-                        Some((TableEntryFlags::RO, true))
-                    }
+    //                 EntryType::BAD_MEMORY => None,
 
-                    EntryType::BAD_MEMORY => None,
+    //                 _ => unreachable!(),
+    //             };
 
-                    _ => unreachable!(),
-                };
+    //             if let Some((flags, lock_frames)) = mmap_args {
+    //                 map_hhdm_range(kmapper, entry_range, flags, lock_frames);
+    //             } else {
+    //                 trace!("HHDM Map (!! BAD MEMORY !!) @{entry_range:#X?}");
+    //             }
+    //         }
 
-                if let Some((flags, lock_frames)) = mmap_args {
-                    map_hhdm_range(kmapper, entry_range, flags, lock_frames);
-                } else {
-                    trace!("HHDM Map (!! BAD MEMORY !!) @{entry_range:#X?}");
-                }
-            }
+    //         /* load kernel segments */
+    //         kernel_elf
+    //             .segments()
+    //             .expect("kernel file has no segments")
+    //             .into_iter()
+    //             .filter(|ph| ph.p_type == elf::abi::PT_LOAD)
+    //             .for_each(|phdr| {
+    //                 unsafe extern "C" {
+    //                     static KERNEL_BASE: libkernel::LinkerSymbol;
+    //                 }
 
-            /* load kernel segments */
-            kernel_elf
-                .segments()
-                .expect("kernel file has no segments")
-                .into_iter()
-                .filter(|ph| ph.p_type == elf::abi::PT_LOAD)
-                .for_each(|phdr| {
-                    unsafe extern "C" {
-                        static KERNEL_BASE: libkernel::LinkerSymbol;
-                    }
+    //                 debug!("{phdr:X?}");
 
-                    debug!("{phdr:X?}");
+    //                 // Safety: `KERNEL_BASE` is a linker symbol to an in-executable memory location, so it is guaranteed to be valid (and is never written to).
+    //                 let base_offset =
+    //                     usize::try_from(phdr.p_vaddr).unwrap() - unsafe { KERNEL_BASE.as_usize() };
+    //                 let base_offset_end = base_offset + usize::try_from(phdr.p_memsz).unwrap();
+    //                 let flags = crate::mem::paging::TableEntryFlags::from(
+    //                     crate::task::segment_to_mmap_permissions(phdr.p_flags),
+    //                 );
 
-                    // Safety: `KERNEL_BASE` is a linker symbol to an in-executable memory location, so it is guaranteed to be valid (and is never written to).
-                    let base_offset =
-                        usize::try_from(phdr.p_vaddr).unwrap() - unsafe { KERNEL_BASE.as_usize() };
-                    let base_offset_end = base_offset + usize::try_from(phdr.p_memsz).unwrap();
-                    let flags = crate::mem::paging::TableEntryFlags::from(
-                        crate::task::segment_to_mmap_permissions(phdr.p_flags),
-                    );
+    //                 (base_offset..base_offset_end)
+    //                     .step_by(page_size())
+    //                     // Attempt to map the page to the frame.
+    //                     .for_each(|offset| {
+    //                         let phys_addr = Address::new(kernel_addr_phys.get() + offset).unwrap();
+    //                         let virt_addr = Address::new(kernel_addr_virt.get() + offset).unwrap();
 
-                    (base_offset..base_offset_end)
-                        .step_by(page_size())
-                        // Attempt to map the page to the frame.
-                        .for_each(|offset| {
-                            let phys_addr = Address::new(kernel_addr_phys.get() + offset).unwrap();
-                            let virt_addr = Address::new(kernel_addr_virt.get() + offset).unwrap();
+    //                         trace!("Map  {virt_addr:X?} -> {phys_addr:X?}   {flags:?}");
+    //                         kmapper
+    //                             .map(virt_addr, TableDepth::min(), phys_addr, true, flags)
+    //                             .expect("failed to map kernel memory region");
+    //                     });
+    //             });
 
-                            trace!("Map  {virt_addr:X?} -> {phys_addr:X?}   {flags:?}");
-                            kmapper
-                                .map(virt_addr, TableDepth::min(), phys_addr, true, flags)
-                                .expect("failed to map kernel memory region");
-                        });
-                });
-
-            debug!("Switching to kernel page tables...");
-            // Safety: Kernel mappings should be identical to the bootloader mappings.
-            unsafe {
-                kmapper.swap_into();
-            }
-            debug!("Kernel has finalized control of page tables.");
-        });
-    }
+    //         debug!("Switching to kernel page tables...");
+    //         // Safety: Kernel mappings should be identical to the bootloader mappings.
+    //         unsafe {
+    //             kmapper.swap_into();
+    //         }
+    //         debug!("Kernel has finalized control of page tables.");
+    //     });
+    // }
 
     /* PARSE ACPI TABLES */
     {
@@ -262,7 +257,8 @@ pub extern "C" fn init() -> ! {
     // Drop into a finalizing function to lose all references
     // to Limine bootloader requests/responses (they will be
     // deallocated during reclamation of bootloader memory).
-    finalize_init(memory_map)
+    // finalize_init(memory_map)
+    todo!()
 }
 
 /// Finalizes the kernel init process. After entering this function, all bootloader
@@ -280,7 +276,7 @@ fn finalize_init(memory_map: &[&memory_map::Entry]) -> ! {
             (entry_start..entry_end).step_by(libsys::page_size())
         })
         .map(|address| Address::<Frame>::new(address).unwrap())
-        .for_each(|frame| crate::mem::pmm::get().free_frame(frame).unwrap());
+        .for_each(|frame| PhysicalMemoryManager::free_frame(frame).unwrap());
 
     debug!("Bootloader memory reclaimed.");
 

--- a/src/kernel/src/init.rs
+++ b/src/kernel/src/init.rs
@@ -84,11 +84,6 @@ pub extern "C" fn init() -> ! {
         )
     };
 
-    // TODO parse the kernel cmdline from limine response
-    // // Parse the kernel parameters.
-    // crate::params::parse_cmdline();
-    // Initialize the physical memory manager.
-
     /* SETUP KERNEL MEMORY */
     {
         use crate::mem::{

--- a/src/kernel/src/mem/alloc.rs
+++ b/src/kernel/src/mem/alloc.rs
@@ -1,58 +1,93 @@
-use crate::mem::pmm;
+use crate::mem::{
+    hhdm,
+    pmm::{self, PhysicalMemoryManager},
+};
 use alloc::alloc::Global;
 use core::{
     alloc::{AllocError, Allocator, GlobalAlloc, Layout},
+    num::NonZeroUsize,
     ptr::NonNull,
 };
+use libsys::{Address, page_shift, page_size};
 
 #[global_allocator]
 static GLOBAL_ALLOCATOR: KernelAllocator = KernelAllocator;
 
 pub struct KernelAllocator;
 
-unsafe impl GlobalAlloc for KernelAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        pmm::get()
-            .allocate(layout)
-            .map_or(core::ptr::null_mut(), |ptr| {
-                trace!(
-                    "Allocation {:?} -> @{:X?}   0x{:X?}",
-                    layout,
-                    ptr,
-                    ptr.as_ref().len()
-                );
-
-                ptr.as_non_null_ptr().as_ptr()
-            })
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        trace!("Deallocation @{:?}   {:?}", ptr, layout);
-        pmm::get().deallocate(NonNull::new(ptr).unwrap(), layout);
-    }
-}
-
+// Safety: PMM utilizes interior mutability & Correct:tm: logic.
 unsafe impl Allocator for KernelAllocator {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
-        pmm::get().allocate(layout)
+    fn allocate(&self, layout: Layout) -> core::result::Result<NonNull<[u8]>, AllocError> {
+        assert!(layout.align() <= page_size());
+
+        let frame_count = libsys::align_up_div(layout.size(), page_shift());
+        let frame = match frame_count.cmp(&1usize) {
+            core::cmp::Ordering::Greater => PhysicalMemoryManager::next_frames(
+                NonZeroUsize::new(frame_count).unwrap(),
+                Some(page_shift()),
+            ),
+
+            core::cmp::Ordering::Equal => PhysicalMemoryManager::next_frame(),
+
+            core::cmp::Ordering::Less => unreachable!(),
+        }
+        // TODO log the error somehow
+        .map_err(|_| AllocError)?;
+
+        let address = hhdm::get().offset(frame).ok_or(AllocError)?;
+
+        Ok(NonNull::slice_from_raw_parts(
+            NonNull::new(address.as_ptr()).unwrap(),
+            frame_count * page_size(),
+        ))
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        pmm::get().deallocate(ptr, layout);
+        assert!(layout.align() <= page_size());
+
+        let offset = ptr.addr().get() - hhdm::get().virt().get();
+        let address = Address::new(offset).unwrap();
+
+        if layout.size() <= page_size() {
+            PhysicalMemoryManager::free_frame(address).ok();
+        } else {
+            let frame_count = libsys::align_up_div(layout.size(), page_shift());
+            let frames_start = address.index();
+            let frames_end = frames_start + frame_count;
+
+            (frames_start..frames_end)
+                .map(Address::from_index)
+                .map(Option::unwrap)
+                .try_for_each(PhysicalMemoryManager::free_frame)
+                .expect("failed while freeing frames");
+        }
+    }
+}
+
+unsafe impl GlobalAlloc for KernelAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.allocate(layout)
+            .map_or(core::ptr::null_mut(), |ptr| ptr.as_non_null_ptr().as_ptr())
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // Safety: Caller is required to guarantee the provided `ptr` and `layout`
+        //         will be valid for a deallocation.
+        unsafe {
+            self.deallocate(NonNull::new(ptr).unwrap(), layout);
+        }
     }
 }
 
 pub struct AlignedAllocator<const ALIGN: usize, A: Allocator = Global>(A);
 
 impl<const ALIGN: usize> AlignedAllocator<ALIGN> {
-    #[inline]
     pub const fn new() -> Self {
         AlignedAllocator::new_in(Global)
     }
 }
 
 impl<const ALIGN: usize, A: Allocator> AlignedAllocator<ALIGN, A> {
-    #[inline]
     pub const fn new_in(allocator: A) -> Self {
         Self(allocator)
     }

--- a/src/kernel/src/mem/mod.rs
+++ b/src/kernel/src/mem/mod.rs
@@ -6,7 +6,7 @@ pub mod paging;
 pub mod pmm;
 
 use self::mapper::Mapper;
-use crate::interrupts::InterruptCell;
+use crate::{interrupts::InterruptCell, mem::pmm::PhysicalMemoryManager};
 
 use core::ptr::NonNull;
 use libsys::{Address, Frame, table_index_size};
@@ -48,8 +48,8 @@ pub fn with_kmapper<T>(func: impl FnOnce(&mut Mapper) -> T) -> T {
     })
 }
 
-pub fn copy_kernel_page_table() -> pmm::Result<Address<Frame>> {
-    let table_frame = pmm::get().next_frame()?;
+pub fn copy_kernel_page_table() -> Result<Address<Frame>, pmm::Error> {
+    let table_frame = PhysicalMemoryManager::next_frame()?;
 
     // Safety: Frame is provided by allocator, and so guaranteed to be within the HHDM, and is frame-sized.
     let new_table = unsafe {
@@ -95,7 +95,7 @@ impl PagingRegister {
         }
     }
 
-    /// Safety
+    /// # Safety
     ///
     /// Writing to this register has the chance to externally invalidate memory references.
     pub unsafe fn write(args: &Self) {

--- a/src/kernel/src/mem/paging/mod.rs
+++ b/src/kernel/src/mem/paging/mod.rs
@@ -7,6 +7,8 @@ use libsys::{
     table_index_size,
 };
 
+use crate::mem::pmm::PhysicalMemoryManager;
+
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TableDepth(u32);
@@ -439,9 +441,7 @@ impl<'a> PageTable<'a, Mut> {
 
                 // Set the entry frame and set attributes to make a valid PTE.
                 *self.entry = PageTableEntry::new(
-                    crate::mem::pmm::get()
-                        .next_frame()
-                        .map_err(|_| Error::AllocError)?,
+                    PhysicalMemoryManager::next_frame().map_err(|_| Error::AllocError)?,
                     flags,
                 );
 

--- a/src/kernel/src/mem/pmm.rs
+++ b/src/kernel/src/mem/pmm.rs
@@ -11,21 +11,21 @@ use spin::RwLock;
 
 static PMM: spin::Once<PhysicalMemoryManager> = spin::Once::new();
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
-    /// There are not enough free frames to satisfy the request.
+    #[error("the physical memory manager is out of free frames")]
     NoneFree,
 
-    /// Given alignment is invalid (e.g. not a power-of-two).
+    #[error("given alignment is invalid (e.g. not a power-of-two)")]
     InvalidAlignment,
 
-    /// The provided frame index was out of bounds of the frame table.
+    #[error("attempted to index out of bounds of the frame table")]
     OutOfBounds,
 
-    /// Attempted to lock a frame that wasn't free.
+    #[error("attempted to lock a frame that wasn't free")]
     NotFree,
 
-    /// Attempted to free a frame that wasn't locked.
+    #[error("attempted to free a frame that wasn't locked")]
     NotLocked,
 }
 

--- a/src/kernel/src/mem/pmm.rs
+++ b/src/kernel/src/mem/pmm.rs
@@ -89,7 +89,7 @@ impl PhysicalMemoryManager {
             assert_eq!(select_region.start & page_mask(), 0);
             assert_eq!(select_region.end & page_mask(), 0);
 
-            trace!("Frame table region: {:X?}", select_region);
+            trace!("Frame table region: {select_region:X?}");
 
             // Safety: Memory map describes HHDM, so this pointer into it will be valid if the bootloader memory map is.s
             let table_start_ptr = unsafe { hhdm::get().ptr().add(select_region.start) };
@@ -205,12 +205,12 @@ impl PhysicalMemoryManager {
             // padding effect of using a `usize` as the underlying data type.
             if index < Self::total_frames() {
                 // if the frame is locked...
-                if !table[index] {
+                if table[index] {
+                    Err(Error::NotLocked)
+                } else {
                     table.set_aliased(index, false);
 
                     Ok(())
-                } else {
-                    Err(Error::NotLocked)
                 }
             } else {
                 Err(Error::OutOfBounds)

--- a/src/kernel/src/mem/pmm.rs
+++ b/src/kernel/src/mem/pmm.rs
@@ -3,12 +3,10 @@ use bitvec::slice::BitSlice;
 use core::{
     alloc::{AllocError, Allocator, Layout},
     num::{NonZeroU32, NonZeroUsize},
-    ops::Range,
     ptr::NonNull,
     sync::atomic::AtomicUsize,
 };
-use libsys::{Address, Frame};
-use libsys::{page_mask, page_shift, page_size};
+use libsys::{Address, Frame, page_mask, page_shift, page_size};
 use spin::RwLock;
 
 #[derive(Debug, Clone, Copy)]
@@ -16,95 +14,30 @@ pub struct InitError;
 
 static PMM: spin::Once<PhysicalMemoryManager> = spin::Once::new();
 
-pub fn init(memory_map: &[&limine::memory_map::Entry]) {
-    PMM.call_once(|| {
-        let free_regions = memory_map
-            .iter()
-            .filter(|&entry| entry.entry_type == limine::memory_map::EntryType::USABLE)
-            .map(|entry| {
-                let region_start = usize::try_from(entry.base).unwrap();
-                let region_end = usize::try_from(entry.base + entry.length).unwrap();
-
-                region_start..region_end
-            });
-
-        let total_memory = memory_map
-            .iter()
-            .map(|e| e.base + e.length)
-            .max()
-            .unwrap()
-            .try_into()
-            .unwrap();
-        trace!("Total phyiscal memory: {total_memory:#X}");
-
-        PhysicalMemoryManager::new(free_regions, total_memory).expect("failed creating pmm")
-    });
-}
-
-pub fn get() -> &'static PhysicalMemoryManager {
-    PMM.get()
-        .expect("physical memory manager has not been initialized")
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
     /// There are not enough free frames to satisfy the request.
     NoneFree,
+
     /// Given alignment is invalid (e.g. not a power-of-two).
     InvalidAlignment,
+
     /// The provided frame index was out of bounds of the frame table.
     OutOfBounds,
+
     /// Attempted to lock a frame that wasn't free.
     NotFree,
+
     /// Attempted to free a frame that wasn't locked.
     NotLocked,
-
-    TypeMismatch,
-
-    Unknown,
 }
 
 pub type Result<T> = core::result::Result<T, Error>;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FrameType {
-    Unusable,
-    Generic,
-    Reserved,
-    BootReclaim,
-    AcpiReclaim,
-}
-
-impl FrameType {
-    const fn from_u8(value: u8) -> Self {
-        match value {
-            0 => Self::Unusable,
-            1 => Self::Generic,
-            2 => Self::Reserved,
-            3 => Self::BootReclaim,
-            4 => Self::AcpiReclaim,
-            _ => unimplemented!(),
-        }
-    }
-
-    const fn as_u8(self) -> u8 {
-        match self {
-            FrameType::Unusable => 0,
-            FrameType::Generic => 1,
-            FrameType::Reserved => 2,
-            FrameType::BootReclaim => 3,
-            FrameType::AcpiReclaim => 4,
-        }
-    }
-}
-
-struct RegionDescriptor {
-    ty: FrameType,
-    region: Range<usize>,
-}
+type FrameTable = RwLock<&'static mut BitSlice<AtomicUsize>>;
 
 pub struct PhysicalMemoryManager {
-    table: InterruptCell<RwLock<&'static mut BitSlice<AtomicUsize>>>,
+    table: InterruptCell<FrameTable>,
+    total_frames: usize,
 }
 
 // Safety: Type uses entirely atomic operations.
@@ -113,62 +46,102 @@ unsafe impl Send for PhysicalMemoryManager {}
 unsafe impl Sync for PhysicalMemoryManager {}
 
 impl PhysicalMemoryManager {
-    pub fn new(
-        free_regions: impl Iterator<Item = Range<usize>>,
-        total_memory: usize,
-    ) -> Option<Self> {
-        let total_frames = total_memory / page_size();
-        let table_slice_len = libsys::align_up_div(
-            total_frames,
-            NonZeroU32::new(usize::BITS.trailing_zeros()).unwrap(),
+    /// Initializes the static physical memory manager with the provided bootloader memory map request.
+    pub fn init(memory_map_request: &limine::request::MemoryMapRequest) {
+        debug_assert!(
+            !PMM.is_completed(),
+            "physical memory manager is already initialized"
         );
-        let table_size_in_frames = libsys::align_up_div(
-            table_slice_len * core::mem::size_of::<usize>(),
-            page_shift(),
-        );
-        let table_size_in_bytes = table_size_in_frames * page_size();
 
-        let select_region = free_regions
-            .filter(|region| (region.start & page_mask()) == 0)
-            .find(|region| region.len() >= table_size_in_bytes)
-            .map(|region| region.start..(region.start + table_size_in_bytes))?;
+        PMM.call_once(|| {
+            let memory_map = memory_map_request
+                .get_response()
+                .expect("no response to memory map request")
+                .entries();
 
-        assert_eq!(select_region.start & page_mask(), 0);
-        assert_eq!(select_region.end & page_mask(), 0);
+            let free_ranges = memory_map
+                .iter()
+                .filter(|&entry| entry.entry_type == limine::memory_map::EntryType::USABLE)
+                .map(|entry| {
+                    let region_start = usize::try_from(entry.base).unwrap();
+                    let region_end = usize::try_from(entry.base + entry.length).unwrap();
 
-        trace!("Selecting region for ledger: {:X?}", select_region);
+                    region_start..region_end
+                });
 
-        // Safety: Memory map describes HHDM, so this pointer into it will be valid if the bootloader memory map is.s
-        let ledger_start_ptr = unsafe { hhdm::get().ptr().add(select_region.start) };
-        // Safety: Unless the memory map lied to us, this memory is valid for a `&[AtomicUsize; total_frames]`.
-        let ledger = BitSlice::from_slice_mut(unsafe {
-            core::slice::from_raw_parts_mut(ledger_start_ptr.cast::<AtomicUsize>(), table_slice_len)
+            let total_memory = memory_map.iter().map(|e| e.base + e.length).max().unwrap();
+            let total_memory = usize::try_from(total_memory).unwrap();
+            trace!("Total phyiscal memory: {}M", total_memory / 1_000_000);
+
+            let total_frames = total_memory / page_size();
+            let table_slice_len = libsys::align_up_div(
+                total_frames,
+                NonZeroU32::new(usize::BITS.trailing_zeros()).unwrap(),
+            );
+            let table_size_in_frames = libsys::align_up_div(
+                table_slice_len * core::mem::size_of::<usize>(),
+                page_shift(),
+            );
+            let table_size_in_bytes = table_size_in_frames * page_size();
+
+            let select_region = free_ranges
+                .filter(|region| (region.start & page_mask()) == 0)
+                .find(|region| region.len() >= table_size_in_bytes)
+                .map(|region| region.start..(region.start + table_size_in_bytes))
+                .expect("bootloader provided no free regions large enough for frame table");
+
+            assert_eq!(select_region.start & page_mask(), 0);
+            assert_eq!(select_region.end & page_mask(), 0);
+
+            trace!("Frame table region: {:X?}", select_region);
+
+            // Safety: Memory map describes HHDM, so this pointer into it will be valid if the bootloader memory map is.s
+            let table_start_ptr = unsafe { hhdm::get().ptr().add(select_region.start) };
+            // Safety: Unless the memory map lied to us, this memory is valid for a `&[AtomicUsize; total_frames]`.
+            let table = BitSlice::from_slice_mut(unsafe {
+                core::slice::from_raw_parts_mut(
+                    table_start_ptr.cast::<AtomicUsize>(),
+                    table_slice_len,
+                )
+            });
+            // Clear the table's bits, so we can populate it later.
+            table.fill(false);
+
+            // Fill the extant bits, as the table may have more bits than there are frames.
+            table[total_frames..].fill(true);
+
+            // Ensure the table's frames are reserved.
+            let table_start_index = select_region.start / page_size();
+            let table_end_index = select_region.end / page_size();
+            table[table_start_index..table_end_index].fill(true);
+
+            Self {
+                table: InterruptCell::new(spin::RwLock::new(table)),
+                total_frames,
+            }
         });
-        ledger.fill(false);
-
-        // Fill the extant bits, as the physical memory bitslice may not be exactly divisible by `usize::BITS`.
-        ledger[total_frames..(table_slice_len * (usize::BITS as usize))].fill(true);
-
-        // Ensure the table pages are reserved.
-        let ledger_start_index = select_region.start / page_size();
-        let ledger_end_index = select_region.end / page_size();
-        ledger[ledger_start_index..ledger_end_index].fill(true);
-
-        Some(Self {
-            table: InterruptCell::new(spin::RwLock::new(ledger)),
-        })
     }
 
-    #[inline]
-    pub fn total_memory(&self) -> usize {
-        self.table.with(|table| {
-            let table = table.read();
-            table.len() * libsys::page_size()
-        })
+    fn get_static() -> &'static Self {
+        PMM.get()
+            .expect("physical memory manager has not been initialized")
     }
 
-    pub fn next_frame(&self) -> Result<Address<Frame>> {
-        self.table.with(|table| {
+    /// Passes the static physical memory manager's frame table to `with_fn`, returning the result.
+    fn with_table<T>(with_fn: impl FnOnce(&FrameTable) -> Result<T>) -> Result<T> {
+        Self::get_static().table.with(with_fn)
+    }
+
+    pub fn total_frames() -> usize {
+        Self::get_static().total_frames
+    }
+
+    pub fn total_memory() -> usize {
+        Self::total_frames() * libsys::page_size()
+    }
+
+    pub fn next_frame() -> Result<Address<Frame>> {
+        Self::with_table(|table| {
             let mut table = table.write();
             let index = table.first_zero().ok_or(Error::NoneFree)?;
             table.set(index, true);
@@ -178,54 +151,73 @@ impl PhysicalMemoryManager {
     }
 
     pub fn next_frames(
-        &self,
         count: NonZeroUsize,
         align_bits: Option<NonZeroU32>,
     ) -> Result<Address<Frame>> {
-        let align_bits = align_bits.unwrap_or(NonZeroU32::MIN).get();
-        let align_index_skip = u32::max(1, align_bits >> page_shift().get());
-        self.table.with(|table| {
+        Self::with_table(|table| {
             let mut table = table.write();
-            let index = table
+
+            let align_bits = align_bits.unwrap_or(NonZeroU32::MIN).get();
+            let align_index_skip = u32::max(1, align_bits >> page_shift().get());
+
+            let free_frames_index = table
                 .windows(count.get())
                 .enumerate()
                 .step_by(align_index_skip.try_into().unwrap())
-                // TODO simplify this to return the window directly.
                 .find_map(|(index, window)| window.not_any().then_some(index))
                 .ok_or(Error::NoneFree)?;
-            let window = table.get_mut(index..(index + count.get())).unwrap();
-            window.fill(true);
 
-            Ok(Address::new(index << page_shift().get()).unwrap())
+            // It's a bit uglier to find the index of the window, then effectively reacreate it. However, `.windows()`
+            // does not return a mutable bitslice, so this is how it must be done.
+            let free_frames = table
+                .get_mut(free_frames_index..(free_frames_index + count.get()))
+                .unwrap();
+            free_frames.fill(true);
+
+            Ok(Address::new(free_frames_index << page_shift().get()).unwrap())
         })
     }
 
-    pub fn lock_frame(&self, address: Address<Frame>) -> Result<()> {
-        self.table.with(|table| {
+    pub fn lock_frame(address: Address<Frame>) -> Result<()> {
+        Self::with_table(|table| {
             let table = table.read();
             let index = address.index();
 
-            if index >= table.len() {
-                Err(Error::OutOfBounds)
-            } else {
-                table.set_aliased(index, true);
+            // The table may have more bits than there are frames due to the
+            // padding effect of using a `usize` as the underlying data type.
+            if index < Self::total_frames() {
+                // if the frame is free...
+                if table[index] {
+                    table.set_aliased(index, true);
 
-                Ok(())
+                    Ok(())
+                } else {
+                    Err(Error::NotFree)
+                }
+            } else {
+                Err(Error::OutOfBounds)
             }
         })
     }
 
-    pub fn free_frame(&self, address: Address<Frame>) -> Result<()> {
-        self.table.with(|table| {
+    pub fn free_frame(address: Address<Frame>) -> Result<()> {
+        Self::with_table(|table| {
             let table = table.read();
             let index = address.index();
 
-            if index >= table.len() {
-                Err(Error::OutOfBounds)
-            } else {
-                table.set_aliased(index, false);
+            // The table may have more bits than there are frames due to the
+            // padding effect of using a `usize` as the underlying data type.
+            if index < Self::total_frames() {
+                // if the frame is locked...
+                if !table[index] {
+                    table.set_aliased(index, false);
 
-                Ok(())
+                    Ok(())
+                } else {
+                    Err(Error::NotLocked)
+                }
+            } else {
+                Err(Error::OutOfBounds)
             }
         })
     }
@@ -239,9 +231,9 @@ unsafe impl Allocator for PhysicalMemoryManager {
         let frame_count = libsys::align_up_div(layout.size(), page_shift());
         let frame = match frame_count.cmp(&1usize) {
             core::cmp::Ordering::Greater => {
-                self.next_frames(NonZeroUsize::new(frame_count).unwrap(), Some(page_shift()))
+                Self::next_frames(NonZeroUsize::new(frame_count).unwrap(), Some(page_shift()))
             }
-            core::cmp::Ordering::Equal => self.next_frame(),
+            core::cmp::Ordering::Equal => Self::next_frame(),
             core::cmp::Ordering::Less => unreachable!(),
         }
         .map_err(|_| AllocError)?;
@@ -260,13 +252,17 @@ unsafe impl Allocator for PhysicalMemoryManager {
         let address = Address::new(offset).unwrap();
 
         if layout.size() <= page_size() {
-            self.free_frame(address).ok();
+            Self::free_frame(address).ok();
         } else {
             let frame_count = libsys::align_up_div(layout.size(), page_shift());
-            for index_offset in 0..frame_count {
-                self.free_frame(Address::from_index(address.index() + index_offset).unwrap())
-                    .ok();
-            }
+            let frames_start = address.index();
+            let frames_end = frames_start + frame_count;
+
+            (frames_start..frames_end)
+                .map(Address::from_index)
+                .map(Option::unwrap)
+                .try_for_each(Self::free_frame)
+                .expect("failed while freeing frames");
         }
     }
 }


### PR DESCRIPTION
The `crate::mem::pmm::PhyscialMemoryManager` type is supposed to only have one instance. Previously, this was achieved with a private static and a `::pmm::get()` function. However, this is somewhat unergonomic / unclear when actually being used, and generally reduces understandability in my opinion. Thus, all methods on `PhysicalMemoryManager` instead reference the static internally, rather than taking `&self` via `::pmm::get()`.